### PR TITLE
Conversion of byte[] to CharPtr

### DIFF
--- a/KopiLua/src/luaconf.cs
+++ b/KopiLua/src/luaconf.cs
@@ -1054,6 +1054,7 @@ namespace KopiLua
 
 			public static implicit operator CharPtr(string str) { return new CharPtr(str); }
 			public static implicit operator CharPtr(char[] chars) { return new CharPtr(chars); }
+			public static implicit operator CharPtr(byte[] bytes) { return new CharPtr(bytes); }
 
 			public CharPtr()
 			{
@@ -1089,6 +1090,17 @@ namespace KopiLua
 			{
 				this.chars = chars;
 				this.index = index;
+			}
+
+			public CharPtr(byte[] bytes)
+			{
+				this.chars = new char[bytes.Length];
+				for (int i = 0; i < bytes.Length; i++)
+				{
+					this.chars[i] = (char)bytes[i];
+				}
+
+				this.index = 0;
 			}
 
 			public CharPtr(IntPtr ptr)


### PR DESCRIPTION
Added support for using byte arrays in loadstring, loadbuffer and
related methods, by adding an implicit encoding-less conversion of
byte[] to CharPtr.

Fixes NLua/NLua's issue #14.
