### PR TITLE
Full implementation of os.date

### DIFF
--- a/KopiLua/src/loslib.cs
+++ b/KopiLua/src/loslib.cs
@@ -422,8 +422,8 @@ namespace KopiLua
 							continue;
 
 						case 'z': // ISO 8601 offset from UTC in timezone (+/-hhmm), or nothing if unavailable
-							string offset = TimeZoneInfo.Local.GetUtcOffset(t).ToString("hhmm");
-							if (!offset.StartsWith("-")) offset = "+" + offset;
+							TimeSpan ts = TimeZoneInfo.Local.GetUtcOffset(t);
+							string offset = (ts.Ticks < 0 ? "-" : "+") + ts.TotalHours.ToString("#00") + ts.Minutes.ToString("00");
 							pt = strftime_add(offset, pt, ptlim);
 							continue;
 


### PR DESCRIPTION
- Fixed default os.date behavior not implemented.
- Fixed format other than "*t" not implemented.

This commit allows standard C date format parameters to be used with
os.date.

The implementation also includes the first ever (?!) C# implementation
of strftime that complies with the standard specification at
http://www.cplusplus.com/reference/ctime/strftime/
