### PR TITLE
Fixed string.gsub crash (backport of 5.2.3)

### DIFF
--- a/KopiLua/src/lstrlib.cs
+++ b/KopiLua/src/lstrlib.cs
@@ -454,8 +454,7 @@ namespace KopiLua
 				  }
 				  break;
 				}
-			  default:
-			  dflt: {  /* pattern class plus optional suffix */
+			  default: dflt: {  /* pattern class plus optional suffix */
 				  CharPtr ep = classend(ms, p);  /* points to optional suffix */
 				  /* does not match at least once? */
 				  if ((s >= ms.src_end) || (singlematch((byte)(s[0]), p, ep) == 0)) {

--- a/KopiLua/src/lstrlib.cs
+++ b/KopiLua/src/lstrlib.cs
@@ -387,111 +387,120 @@ namespace KopiLua
 		}
 
 
-		private static CharPtr match (MatchState ms, CharPtr s, CharPtr p) {
+		private static CharPtr match(MatchState ms, CharPtr s, CharPtr p) {
 		  s = new CharPtr(s);
 		  p = new CharPtr(p);
 		  if (ms.matchdepth-- == 0)
-			  LuaLError(ms.L, "pattern too complex");
+			LuaLError(ms.L, "pattern too complex");
 		  init: /* using goto's to optimize tail recursion */
-		  switch (p[0]) {
-			case '(': {  /* start capture */
-			  if (p[1] == ')')  /* position capture? */
-				return start_capture(ms, s, p+2, CAP_POSITION);
-			  else
-				return start_capture(ms, s, p+1, CAP_UNFINISHED);
-			}
-			case ')': {  /* end capture */
-			  return end_capture(ms, s, p+1);
-			}
-			case L_ESC: {
-			  switch (p[1]) {
-				case 'b': {  /* balanced string? */
-				  s = matchbalance(ms, s, p+2);
-				  if (s == null) return null;
-				  p+=4; goto init;  /* else return match(ms, s, p+4); */
-				}
-				case 'f': {  /* frontier? */
-				  CharPtr ep; char previous;
-				  p += 2;
-				  if (p[0] != '[')
-					LuaLError(ms.L, "missing " + LUA_QL("[") + " after " +
-									   LUA_QL("%%f") + " in pattern");
-				  ep = classend(ms, p);  /* points to what is next */
-				  previous = (s == ms.src_init) ? '\0' : s[-1];
-				  if ((matchbracketclass((byte)(previous), p, ep-1)!=0) ||
-					 (matchbracketclass((byte)(s[0]), p, ep-1)==0)) return null;
-				  p=ep; goto init;  /* else return match(ms, s, ep); */
-				}
-				default: {
-				  if (isdigit((byte)(p[1]))) {  /* capture results (%0-%9)? */
-					s = match_capture(ms, s, (byte)(p[1]));
-					if (s == null) return null;
-					p+=2; goto init;  /* else return match(ms, s, p+2) */
+		  if (p != '\0') { /* end of pattern? */
+			switch (p[0]) {
+			  case '(': {  /* start capture */
+				  if (p[1] == ')') {  /* position capture? */
+					s = start_capture(ms, s, p + 2, CAP_POSITION);
 				  }
-					//ismeretlen hiba miatt lett ide átmásolva
-				{  /* it is a pattern item */
-			  CharPtr ep = classend(ms, p);  /* points to what is next */
-			  int m = (s<ms.src_end) && (singlematch((byte)(s[0]), p, ep)!=0) ? 1 : 0;
-			  switch (ep[0]) {
-				case '?': {  /* optional */
-				  CharPtr res;
-				  if ((m!=0) && ((res=match(ms, s+1, ep+1)) != null))
-					return res;
-				  p=ep+1; goto init;  /* else return match(ms, s, ep+1); */
+				  else {
+					s = start_capture(ms, s, p + 1, CAP_UNFINISHED);
+				  }
+				  break;
 				}
-				case '*': {  /* 0 or more repetitions */
-				  return max_expand(ms, s, p, ep);
+			  case ')': {  /* end capture */
+				  s = end_capture(ms, s, p + 1);
+				  break;
 				}
-				case '+': {  /* 1 or more repetitions */
-				  return ((m!=0) ? max_expand(ms, s+1, p, ep) : null);
+			  case '$': {
+				  if (p[1] != '\0') {  /* is the `$' the last char in pattern? */
+					goto dflt; /* no; go to default */
+				  }
+				  s = (s == ms.src_end) ? s : null;  /* check end of string */
+				  break;
 				}
-				case '-': {  /* 0 or more repetitions (minimum) */
-				  return min_expand(ms, s, p, ep);
+			  case L_ESC: { /* escaped sequences not in the format class[*+?-]? */
+				  switch (p[1]) {
+					case 'b': {  /* balanced string? */
+						s = matchbalance(ms, s, p + 2);
+						if (s != null) {
+						  p += 4; goto init;  /* return match(ms, s, p+4); */
+						}
+						/* else fail (s == NULL) */
+						break;
+					  }
+					case 'f': {  /* frontier? */
+						CharPtr ep; char previous;
+						p += 2;
+						if (p[0] != '[') {
+						  LuaLError(ms.L, "missing " + LUA_QL("[") + " after " +
+									  LUA_QL("%%f") + " in pattern");
+						}
+						ep = classend(ms, p);  /* points to what is next */
+						previous = (s == ms.src_init) ? '\0' : s[-1];
+						if ((matchbracketclass((byte)(previous), p, ep - 1) == 0) ||
+						  (matchbracketclass((byte)(s[0]), p, ep - 1) != 0)) {
+						  p = ep; goto init; /* else return match(ms, s, ep); */
+						}
+						s = null;  /* match failed */
+						break;
+					  }
+					default: {
+						if (isdigit((byte)(p[1]))) {  /* capture results (%0-%9)? */
+						  s = match_capture(ms, s, (byte)(p[1]));
+						  if (s != null) {
+							p += 2; goto init;  /* else return match(ms, s, p+2) */
+						  }
+						  break;
+						}
+						goto dflt;
+					  }
+				  }
+				  break;
 				}
-				default: {
-				  if (m==0) return null;
-				  s = s.next(); p=ep; goto init;  /* else return match(ms, s+1, ep); */
+			  default:
+			  dflt: {  /* pattern class plus optional suffix */
+				  CharPtr ep = classend(ms, p);  /* points to optional suffix */
+				  /* does not match at least once? */
+				  if ((s >= ms.src_end) || (singlematch((byte)(s[0]), p, ep) == 0)) {
+					if (ep == '*' || ep == '?' || ep == '-') { /* accept empty? */
+					  p = ep + 1; goto init; /* return match(ms, s, ep + 1); */
+					}
+					else  /* '+' or no suffix */
+					  s = null; /* fail */
+				  }
+				  else { /* matched once */
+					switch (ep[0]) {
+					  case '?': {  /* optional */
+						  CharPtr res;
+						  if ((res = match(ms, s + 1, ep + 1)) != null) {
+							s = res;
+						  }
+						  else {
+							p = ep + 1; goto init;  /* else return match(ms, s, ep+1); */
+						  }
+						  break;
+						}
+					  case '+': {  /* 1 or more repetitions */
+						  s = s.next(); /* 1 match already done */
+						  s = max_expand(ms, s, p, ep); // cannot fall through, repeating '*' instruction instead.
+						  break;
+						}
+					  case '*': {  /* 0 or more repetitions */
+						  s = max_expand(ms, s, p, ep);
+						  break;
+						}
+					  case '-': {  /* 0 or more repetitions (minimum) */
+						  s = min_expand(ms, s, p, ep);
+						  break;
+						}
+					  default: { /* no suffix */
+						  s = s.next(); p = ep; goto init;  /* return match(ms, s+1, ep); */
+						}
+					}
+				  }
+				  break;
 				}
-			  }
-			}
-				  //goto dflt;  /* case default */
-				}
-			  }
-			}
-			case '\0': {  /* end of pattern */
-			  return s;  /* match succeeded */
-			}
-			case '$': {
-			  if (p[1] == '\0')  /* is the `$' the last char in pattern? */
-				return (s == ms.src_end) ? s : null;  /* check end of string */
-			  else goto dflt;
-			}
-			default: dflt: {  /* it is a pattern item */
-			  CharPtr ep = classend(ms, p);  /* points to what is next */
-			  int m = (s<ms.src_end) && (singlematch((byte)(s[0]), p, ep)!=0) ? 1 : 0;
-			  switch (ep[0]) {
-				case '?': {  /* optional */
-				  CharPtr res;
-				  if ((m!=0) && ((res=match(ms, s+1, ep+1)) != null))
-					return res;
-				  p=ep+1; goto init;  /* else return match(ms, s, ep+1); */
-				}
-				case '*': {  /* 0 or more repetitions */
-				  return max_expand(ms, s, p, ep);
-				}
-				case '+': {  /* 1 or more repetitions */
-				  return ((m!=0) ? max_expand(ms, s+1, p, ep) : null);
-				}
-				case '-': {  /* 0 or more repetitions (minimum) */
-				  return min_expand(ms, s, p, ep);
-				}
-				default: {
-				  if (m==0) return null;
-				  s = s.next(); p=ep; goto init;  /* else return match(ms, s+1, ep); */
-				}
-			  }
 			}
 		  }
+		  ms.matchdepth++;
+		  return s;
 		}
 
 

--- a/tests/core.cs
+++ b/tests/core.cs
@@ -128,5 +128,31 @@ namespace Tests.iOS
 		{
 			TestLuaFile ("trace-globals");
 		}
+		
+		[Test]
+        public void StringLib()
+        {
+            // Tests for string.gsub working with more than MAXCALLS characters.
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append('a', Lua.MAXCCALLS);
+            string before = sb.ToString() + " RR " + "TRAIL";
+            string after = sb.ToString() + " 123456789 " + "TRAIL";
+
+            string str = "assert(string.gsub(\"" + before + "\", \"RR\", \"123456789\") == \"" + after +"\")";
+            
+            if (Lua.LuaLLoadString(state, str) != 0)
+            {
+                var error = Lua.LuaToString(state, -1);
+                Lua.LuaPop(state, 1);
+
+                Assert.Fail("LoadString failed.");
+            }
+
+            if (Lua.LuaPCall(state, 0, 0, 0) != 0)
+            {
+                Assert.Fail("Function call failed: " + Lua.LuaToString(state, -1).ToString());
+            }
+        }
 	}
 }


### PR DESCRIPTION
b2de9216a2055725408ef04f520b208b8d05ee3c introduced a bug where _str_gsub_ would crash if input string had more than _MAXCCALLS_ characters.

This commit solves this problem by replacing _match_ by its latest version (5.2.3 at http://www.lua.org/source/5.2/lstrlib.c.html#match).