### PR TITLE
Now can to read UTF-8 encoded file with BOM(0xEFBBBF)

### DIFF
--- a/KopiLua/src/lauxlib.cs
+++ b/KopiLua/src/lauxlib.cs
@@ -704,6 +704,20 @@ namespace KopiLua
 		   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
 			lf.extraline = 0;
 		  }
+		  if (c == UTF8_SIGNATURE[0] && (filename != null)) {
+			int c1 = getc(lf.f);
+			if (c1 != UTF8_SIGNATURE[1]) ungetc(c1, lf.f);
+			else {
+			  int c2 = getc(lf.f);
+			  if (c2 != UTF8_SIGNATURE[2]) {
+				ungetc(c2, lf.f);
+				ungetc(c1, lf.f);
+			  }
+			  else
+				c = getc(lf.f);
+			}
+		  }
+
 		  ungetc(c, lf.f);
 		  status = LuaLoad(L, GetF, lf, LuaToString(L, -1));
 		  readstatus = ferror(lf.f);

--- a/KopiLua/src/lua.cs
+++ b/KopiLua/src/lua.cs
@@ -59,6 +59,9 @@ namespace KopiLua
 		/* mark for precompiled code (`<esc>Lua') */
 		public const string LUA_SIGNATURE = "\x01bLua";
 
+		/* Byte order mark of UTF-8 Encoding */
+		public const string UTF8_SIGNATURE = "\xEF\xBB\xBF";
+
 		/* option for multiple returns in `lua_pcall' and `lua_call' */
 		public const int LUA_MULTRET	= (-1);
 


### PR DESCRIPTION
KopiLua threw exception when try to read UTF8 BOM with error message:
```test.lua:1: '=' expected near '»'```
, but now will not reject file